### PR TITLE
added support for kubeconfig and context flag to kyverno apply

### DIFF
--- a/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
+++ b/cmd/cli/kubectl-kyverno/apply/apply_command_test.go
@@ -71,7 +71,7 @@ func Test_Apply(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		_, _, _, info, _ := applyCommandHelper(tc.ResourcePaths, "", false, true, "", "", "", "", tc.PolicyPaths, false, false)
+		_, _, _, info, _ := applyCommandHelper(tc.ResourcePaths, "", false, true, "", "", "", "", tc.PolicyPaths, false, false, "", "")
 		resps := buildPolicyReports(info)
 		for i, resp := range resps {
 			compareSummary(tc.expectedPolicyReports[i].Summary, resp.UnstructuredContent()["summary"].(map[string]interface{}))

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	rest "k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 )
@@ -31,4 +32,13 @@ func createClientConfig(kubeconfig string) (*rest.Config, error) {
 	}
 	logger.V(4).Info("Using specified kubeconfig", "kubeconfig", kubeconfig)
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// CreateClientConfigWithContext creates client config from custom kubeconfig file and context
+// Used for cli commands
+func CreateClientConfigWithContext(kubeconfig string, context string) (*rest.Config, error) {
+	kubernetesConfig := genericclioptions.NewConfigFlags(true)
+	kubernetesConfig.KubeConfig = &kubeconfig
+	kubernetesConfig.Context = &context
+	return kubernetesConfig.ToRESTConfig()
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -64,4 +66,124 @@ func createMinimalKubeconfig(t *testing.T) string {
 	assert.NilError(t, f.Close())
 
 	return f.Name()
+}
+
+func createCustomKubeConfig(t *testing.T, fileName string, hosts map[string]string, currentContext string) {
+	t.Helper()
+	err := ioutil.WriteFile(fileName, []byte(fmt.Sprintf(`
+apiVersion: v1
+clusters:
+- cluster:
+    server: %s
+  name: dev
+- cluster:
+    server: %s
+  name: qa
+contexts:
+- context:
+    cluster: dev
+    user: dev
+  name: dev
+- context:
+    cluster: qa
+    user: qa
+  name: qa
+current-context: %s
+kind: Config
+preferences: {}
+users:
+- name: dev
+  user: {}
+- name: qa
+  user: {}
+
+`, hosts["dev"], hosts["qa"], currentContext)), os.FileMode(0755))
+	assert.NilError(t, err)
+}
+
+func Test_CreateCustomClientConfig_WithContext(t *testing.T) {
+	pwd, _ := os.Getwd()
+	customKubeConfig := pwd + "/kubeConfig"
+	hosts := map[string]string{
+		"dev": "http://127.0.0.1:8081",
+		"qa":  "http://127.0.0.2:8082",
+	}
+	currentContext := "dev"
+	createCustomKubeConfig(t, customKubeConfig, hosts, currentContext)
+	defer os.Remove(customKubeConfig)
+
+	testCases := []struct {
+		testName   string
+		kubeConfig string
+		context    string
+		host       string
+	}{
+		{
+			testName:   "default kubeconfig",
+			kubeConfig: "",
+			context:    "",
+		},
+		{
+			testName:   "custom kubeconfig file with current-context as dev",
+			kubeConfig: customKubeConfig,
+			context:    "",
+			host:       hosts["dev"],
+		},
+		{
+			testName:   "custom kubeconfig file with custom context as qa",
+			kubeConfig: customKubeConfig,
+			context:    "qa",
+			host:       hosts["qa"],
+		},
+	}
+
+	for _, test := range testCases {
+		restConfig, err := config.CreateClientConfigWithContext(test.kubeConfig, test.context)
+		assert.NilError(t, err, fmt.Sprintf("test %s failed", test.testName))
+		if test.host != "" {
+			assert.Equal(t, restConfig.Host, test.host, fmt.Sprintf("test %s failed", test.testName))
+		}
+	}
+
+	t.Setenv("KUBECONFIG", customKubeConfig) // use custom kubeconfig instead of ~/.kube/config
+	newCustomKubeConfig := pwd + "/newkubeConfig"
+	newHosts := map[string]string{
+		"dev": "http://127.0.0.1:8083",
+		"qa":  "http://127.0.0.2:8084",
+	}
+	createCustomKubeConfig(t, newCustomKubeConfig, newHosts, currentContext)
+	defer os.Remove(newCustomKubeConfig)
+	testCases = []struct {
+		testName   string
+		kubeConfig string
+		context    string
+		host       string
+	}{
+		{
+			testName:   "kubeconfig file from env with current-context as dev",
+			kubeConfig: "",
+			context:    "",
+			host:       hosts["dev"],
+		},
+		{
+			testName:   "kubeconfig file from env with custom context as qa",
+			kubeConfig: "",
+			context:    "qa",
+			host:       hosts["qa"],
+		},
+		{
+			testName:   "override kubeconfig from env with new kubeconfig and custom context as qa",
+			kubeConfig: newCustomKubeConfig,
+			context:    "qa",
+			host:       newHosts["qa"],
+		},
+	}
+
+	for _, test := range testCases {
+		restConfig, err := config.CreateClientConfigWithContext(test.kubeConfig, test.context)
+		assert.NilError(t, err, fmt.Sprintf("test %s failed", test.testName))
+		if test.host != "" {
+			assert.Equal(t, restConfig.Host, test.host, fmt.Sprintf("test %s failed", test.testName))
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Sandesh More <morelsandesh@gmail.com>

## Explanation

previously ```kyverno apply``` command only supported default kubeconfig file or kubeconfig file from KUBECONFIG env variable with current-context. This PR intends to add a flags to kyverno apply command to support use of seperate kubeconfig file and context.

## Related issue

closes: 2317

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this
/kind feature
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

add cli flags namely ```kubeconfig``` and ```context``` in ```kyverno apply``` command while creating kubeclient

### Proof Manifests
for testing i have two kubeconfig files 

#### default kubeconfig
```
$ kubectl config get-contexts
CURRENT   NAME                CLUSTER     AUTHINFO    NAMESPACE
          developer-context
          kind-c1             kind-c1     kind-c1
*         kind-kind           kind-kind   kind-kind   default
````
#### seperate kubeconfig
```
$ kubectl --kubeconfig ~/newkubeconfig config get-contexts
CURRENT   NAME      CLUSTER   AUTHINFO   NAMESPACE
*         kind-c2   kind-c2   kind-c2
          kind-c3   kind-c3   kind-c3  
```

each cluster-context has one pod in default namespace failing for policy check-for-labels

https://raw.githubusercontent.com/kyverno/policies/main/best-practices/require_labels/require_labels.yaml

to switch different context and kubeconfig with flags introduced in this PR:

#### change only context
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --context kind-c1 /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c1-nginx failed:
1. check-for-labels: validation error: label '[app.kubernetes.io/name](http://app.kubernetes.io/name)' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c1-nginx``` from cluster ```kind-c1``` as i specified --context ```kind-c1``` in command

#### change kubeconfig
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --kubeconfig /home/sandesh/newkubeconfig  /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c2-nginx failed:
1. check-for-labels: validation error: label 'app.kubernetes.io/name' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c2-nginx``` from cluster ```kind-c2``` as i specified kubeconfig where current-context is ```kind-c2``` cluster

#### change both kubeconfig and context
```
$ ./cmd/cli/kubectl-kyverno/kubectl-kyverno  apply --kubeconfig /home/sandesh/newkubeconfig --context kind-c3 /home/sandesh/require-labels-pol.yaml --cluster --namespace default
Applying 1 policy rule to 1 resource...
policy require-labels -> resource default/Pod/c3-nginx failed:
1. check-for-labels: validation error: label 'app.kubernetes.io/name' is required. rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
pass: 0, fail: 1, warn: 0, error: 0, skip: 2
```
here policy failed for pod ```c3-nginx``` from cluster ```kind-c3``` as i specified kubeconfig with cluster ```kind-c2``` in command

Note: kubeconfig file set with ```KUBECONFIG``` env varibale will be overriden by cli flag ```--kubeconfig```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
