### PR TITLE
Fixes issue-4589: Test summary table doesn't show individual line numbers

### DIFF
--- a/cmd/cli/kubectl-kyverno/test/test_command.go
+++ b/cmd/cli/kubectl-kyverno/test/test_command.go
@@ -1036,7 +1036,6 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 	boldYellow := color.New(color.FgYellow).Add(color.Bold)
 	boldFgCyan := color.New(color.FgCyan).Add(color.Bold)
 
-	var countDeprecatedResource int
 	for i, v := range testResults {
 		res := new(Table)
 		res.ID = i + 1
@@ -1049,7 +1048,9 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 		}
 
 		if v.Resources != nil {
-			for _, resource := range v.Resources {
+			tableCurrentLength := len(table) + 1
+			for resIndex, resource := range v.Resources {
+				res.ID = tableCurrentLength + resIndex
 				if !removeColor {
 					res.Resource = boldFgCyan.Sprintf(v.Namespace) + "/" + boldFgCyan.Sprintf(v.Kind) + "/" + boldFgCyan.Sprintf(resource)
 				} else {
@@ -1137,7 +1138,6 @@ func printTestResult(resps map[string]policyreportv1alpha2.PolicyReportResult, t
 				}
 			}
 		} else if v.Resource != "" {
-			countDeprecatedResource++
 			if !removeColor {
 				res.Resource = boldFgCyan.Sprintf(v.Namespace) + "/" + boldFgCyan.Sprintf(v.Kind) + "/" + boldFgCyan.Sprintf(v.Resource)
 			} else {

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -310,7 +310,7 @@ func (iv *imageVerifier) verifyAttestorSet(attestorSet kyvernov1.AttestorSet, im
 ) (*cosign.Response, error) {
 	var errorList []error
 	verifiedCount := 0
-	attestorSet = expandStaticKeys(attestorSet)
+	attestorSet = expandKeysData(attestorSet)
 	requiredCount := getRequiredCount(attestorSet)
 	image := imageInfo.String()
 
@@ -353,6 +353,44 @@ func (iv *imageVerifier) verifyAttestorSet(attestorSet kyvernov1.AttestorSet, im
 	iv.logger.Info("image verification failed", "verifiedCount", verifiedCount, "requiredCount", requiredCount, "errors", errorList)
 	err := multierr.Combine(errorList...)
 	return nil, err
+}
+
+func expandKeysData(attestorSet kyvernov1.AttestorSet) kyvernov1.AttestorSet {
+	attestorSet = expandStaticKeys(attestorSet)
+	attestorSet = extractSecret(attestorSet)
+	attestorSet = extractKms(attestorSet)
+	return attestorSet
+}
+
+func extractSecret(attestorSet kyvernov1.AttestorSet) kyvernov1.AttestorSet {
+	var entries []kyvernov1.Attestor
+	if len(attestorSet.Entries) > 0 {
+		entries = attestorSet.Entries
+	}
+	for _, e := range attestorSet.Entries {
+		if e.Keys != nil && e.Keys.Secret != nil {
+			secretData := &kyvernov1.SecretReference{
+				Name: e.Keys.Secret.Name, Namespace: e.Keys.Secret.Namespace,
+			}
+			a := kyvernov1.Attestor{Keys: &kyvernov1.StaticKeyAttestor{Secret: secretData}}
+			entries = append(entries, a)
+		}
+	}
+	return kyvernov1.AttestorSet{Count: attestorSet.Count, Entries: entries}
+}
+
+func extractKms(attestorSet kyvernov1.AttestorSet) kyvernov1.AttestorSet {
+	var entries []kyvernov1.Attestor
+	if len(attestorSet.Entries) > 0 {
+		entries = attestorSet.Entries
+	}
+	for _, e := range attestorSet.Entries {
+		if e.Keys != nil && e.Keys.KMS != "" {
+			a := kyvernov1.Attestor{Keys: &kyvernov1.StaticKeyAttestor{KMS: e.Keys.KMS}}
+			entries = append(entries, a)
+		}
+	}
+	return kyvernov1.AttestorSet{Count: attestorSet.Count, Entries: entries}
 }
 
 func expandStaticKeys(attestorSet kyvernov1.AttestorSet) kyvernov1.AttestorSet {


### PR DESCRIPTION
## Explanation
This fix addresses issue-4589 where `results[].resources[]` were giving line numbers per group. 
Also, since changes for issue-4590 are very minor, added fix for it in the same PR.

## Related issue
- issue-4589
- issue-4590

## What type of PR is this
/kind bug

## Proposed Changes

### Proof Manifests
`disallow-privileged-containers.yaml`
```
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: disallow-privileged-containers
  annotations:
    policies.kyverno.io/title: Disallow Privileged Containers
    policies.kyverno.io/category: Pod Security Standards (Baseline)
    policies.kyverno.io/severity: medium
    policies.kyverno.io/subject: Pod
    kyverno.io/kyverno-version: 1.6.0
    kyverno.io/kubernetes-version: "1.22-1.23"
    policies.kyverno.io/description: >-
      Privileged mode disables most security mechanisms and must not be allowed. This policy
      ensures Pods do not call for privileged mode.
spec:
  validationFailureAction: audit
  background: true
  rules:
    - name: privileged-containers
      match:
        any:
        - resources:
            kinds:
              - Pod
      validate:
        message: >-
          Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
          and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
        pattern:
          spec:
            =(ephemeralContainers):
              - =(securityContext):
                  =(privileged): "false"
            =(initContainers):
              - =(securityContext):
                  =(privileged): "false"
            containers:
              - =(securityContext):
                  =(privileged): "false"
```
`resource.yaml`
```
###### Pods - Bad
---
apiVersion: v1
kind: Pod
metadata:
  name: badpod01
spec:
  containers:
  - name: container01
    image: dummyimagename
    securityContext:
      privileged: true
---
apiVersion: v1
kind: Pod
metadata:
  name: badpod02
spec:
  containers:
  - name: container01
    image: dummyimagename
  - name: container02
    image: dummyimagename
    securityContext:
      privileged: true
---
###### Pods - Good
apiVersion: v1
kind: Pod
metadata:
  name: goodpod01
spec:
  containers:
  - name: container01
    image: dummyimagename
---
apiVersion: v1
kind: Pod
metadata:
  name: goodpod02
spec:
  containers:
  - name: container01
    image: dummyimagename
    securityContext:
      privileged: false
---
###### Deployments - Bad
apiVersion: apps/v1
kind: Deployment
metadata:
  name: baddeployment01
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
    spec:
      containers:
      - name: container01
        image: dummyimagename
        securityContext:
          privileged: true
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: baddeployment02
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
    spec:
      containers:
      - name: container01
        image: dummyimagename
      - name: container02
        image: dummyimagename
        securityContext:
          privileged: true
---
###### Deployments - Good
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gooddeployment01
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
    spec:
      containers:
      - name: container01
        image: dummyimagename
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gooddeployment02
spec:
  replicas: 1
  selector:
    matchLabels:
      app: app
  template:
    metadata:
      labels:
        app: app
    spec:
      containers:
      - name: container01
        image: dummyimagename
        securityContext:
          privileged: false
---
###### CronJobs - Bad
apiVersion: batch/v1
kind: CronJob
metadata:
  name: badcronjob01
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: OnFailure
          containers:
          - name: container01
            image: dummyimagename
            securityContext:
              privileged: true
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: badcronjob02
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: OnFailure
          containers:
          - name: container01
            image: dummyimagename
          - name: container02
            image: dummyimagename
            securityContext:
              privileged: true
---
###### CronJobs - Good
apiVersion: batch/v1
kind: CronJob
metadata:
  name: goodcronjob01
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: OnFailure
          containers:
          - name: container01
            image: dummyimagename
---
apiVersion: batch/v1
kind: CronJob
metadata:
  name: goodcronjob02
spec:
  schedule: "*/1 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: OnFailure
          containers:
          - name: container01
            image: dummyimagename
            securityContext:
              privileged: false
```
`test.yaml`
```
name: disallow-privileged-containers
policies:
  - disallow-privileged-containers.yaml
resources:
  - resource.yaml
results:
###### Pods - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: badpod01
    kind: Pod
    result: fail
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: badpod02
    kind: Pod
    result: fail
###### Pods - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: goodpod01
    kind: Pod
    result: pass
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: goodpod02
    kind: Pod
    result: pass
###### Deployments - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: baddeployment01
    kind: Deployment
    result: fail
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: baddeployment02
    kind: Deployment
    result: fail
###### Deployments - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: gooddeployment01
    kind: Deployment
    result: pass
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: gooddeployment02
    kind: Deployment
    result: pass
###### CronJobs - Bad
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: badcronjob01
    kind: CronJob
    result: fail
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resource: badcronjob02
    kind: CronJob
    result: fail
###### CronJobs - Good
  - policy: disallow-privileged-containers
    rule: privileged-containers
    resources:
    - goodcronjob01
    - goodcronjob02
    kind: CronJob
    result: pass
```
Results:
```
Executing disallow-privileged-containers...
applying 1 policy to 12 resources... 

│─────────│────────────────────────────────│───────────────────────│───────────────────────────────│────────│
│ # (12)  │ POLICY                         │ RULE                  │ RESOURCE                      │ RESULT │
│─────────│────────────────────────────────│───────────────────────│───────────────────────────────│────────│
│       1 │ disallow-privileged-containers │ privileged-containers │ /Pod/badpod01                 │ Pass   │
│       2 │ disallow-privileged-containers │ privileged-containers │ /Pod/badpod02                 │ Pass   │
│       3 │ disallow-privileged-containers │ privileged-containers │ /Pod/goodpod01                │ Pass   │
│       4 │ disallow-privileged-containers │ privileged-containers │ /Pod/goodpod02                │ Pass   │
│       5 │ disallow-privileged-containers │ privileged-containers │ /Deployment/baddeployment01   │ Pass   │
│       6 │ disallow-privileged-containers │ privileged-containers │ /Deployment/baddeployment02   │ Pass   │
│       7 │ disallow-privileged-containers │ privileged-containers │ /Deployment/gooddeployment01  │ Pass   │
│       8 │ disallow-privileged-containers │ privileged-containers │ /Deployment/gooddeployment02  │ Pass   │
│       9 │ disallow-privileged-containers │ privileged-containers │ /CronJob/badcronjob01         │ Pass   │
│      10 │ disallow-privileged-containers │ privileged-containers │ /CronJob/badcronjob02         │ Pass   │
│      11 │ disallow-privileged-containers │ privileged-containers │ default/CronJob/goodcronjob01 │ Pass   │
│      12 │ disallow-privileged-containers │ privileged-containers │ default/CronJob/goodcronjob02 │ Pass   │
│─────────│────────────────────────────────│───────────────────────│───────────────────────────────│────────│

Test Summary: 12 tests passed and 0 tests failed
```
## Checklist

- [x ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.