### PR TITLE
Issue 3058

### DIFF
--- a/api/kyverno/v1/spec_test.go
+++ b/api/kyverno/v1/spec_test.go
@@ -49,3 +49,125 @@ func Test_Validate_UniqueRuleName(t *testing.T) {
 	assert.Equal(t, errs[0].Type, field.ErrorTypeInvalid)
 	assert.Equal(t, errs[0].Detail, "Duplicate rule name: 'deny-privileged-disallowpriviligedescalation'")
 }
+
+func Test_Validate_Namespaces(t *testing.T) {
+	path := field.NewPath("dummy")
+	testcases := []struct {
+		description        string
+		spec               Spec
+		expectedSpecErrIdx int //variable to get the index from the Spec.ValidationFailureActionOverrides field
+		errors             func(v *ValidationFailureActionOverride) field.ErrorList
+	}{
+		{
+			description: "Duplicate Namespace in 2nd resource(validation)",
+			spec: Spec{
+				ValidationFailureAction: Enforce,
+				ValidationFailureActionOverrides: []ValidationFailureActionOverride{
+					{
+						Action: Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []Rule{
+					{
+						Name: "require-labels",
+						MatchResources: MatchResources{
+							ResourceDescription: ResourceDescription{
+								Kinds: []string{
+									"Pod",
+								},
+							},
+						},
+						Validation: Validation{
+							Message: "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{
+								Raw: []byte(`
+							"metadata": {
+								"lables": {
+									"app.kubernetes.io/name": "?*"
+								}
+							}`),
+							},
+						},
+					},
+				},
+			},
+			expectedSpecErrIdx: 1,
+			errors: func(v *ValidationFailureActionOverride) (errs field.ErrorList) {
+				return append(errs, field.Invalid(field.NewPath("dummy.validationFailureActionOverrides[1].namespaces"), v, "Duplicate namespaces found: default"))
+			},
+		},
+		{
+			description: "Duplicate Namespace in 2nd resource(mutate)",
+			spec: Spec{
+				ValidationFailureAction: Enforce,
+				ValidationFailureActionOverrides: []ValidationFailureActionOverride{
+					{
+						Action: Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []Rule{
+					{
+						Name: "add-labels",
+						MatchResources: MatchResources{
+							ResourceDescription: ResourceDescription{
+								Kinds: []string{
+									"Pod",
+								},
+							},
+						},
+						Mutation: Mutation{
+							RawPatchStrategicMerge: &apiextv1.JSON{
+								Raw: []byte(`
+								"metadata": {
+									"labels": {
+										"app-name": "{{request.object.metadata.name}}"
+									}
+								}`),
+							},
+						},
+					},
+				},
+			},
+			expectedSpecErrIdx: 1,
+			errors: func(v *ValidationFailureActionOverride) (errs field.ErrorList) {
+				return append(errs, field.Invalid(field.NewPath("dummy.validationFailureActionOverrides[1].namespaces"), v, "Duplicate namespaces found: default"))
+			},
+		},
+	}
+
+	for _, ts := range testcases {
+		t.Run(ts.description, func(t *testing.T) {
+			errs := ts.spec.Validate(path, false, nil)
+
+			var expectedErrs field.ErrorList
+			if ts.errors != nil {
+				expectedErrs = ts.errors(&ts.spec.ValidationFailureActionOverrides[ts.expectedSpecErrIdx])
+			}
+
+			assert.Equal(t, len(errs), len(expectedErrs))
+			for i := range errs {
+				assert.Equal(t, errs[i].Error(), expectedErrs[i].Error())
+			}
+		})
+	}
+}

--- a/api/kyverno/v2beta1/spec_test.go
+++ b/api/kyverno/v2beta1/spec_test.go
@@ -53,3 +53,129 @@ func Test_Validate_UniqueRuleName(t *testing.T) {
 	assert.Equal(t, errs[0].Type, field.ErrorTypeInvalid)
 	assert.Equal(t, errs[0].Detail, "Duplicate rule name: 'deny-privileged-disallowpriviligedescalation'")
 }
+
+func Test_Validate_Namespaces(t *testing.T) {
+	path := field.NewPath("dummy")
+	testcases := []struct {
+		description        string
+		spec               Spec
+		expectedSpecErrIdx int //variable to get the index from the Spec.ValidationFailureActionOverrides field
+		errors             func(v *kyvernov1.ValidationFailureActionOverride) field.ErrorList
+	}{
+		{
+			description: "Duplicate Namespace in 2nd resource(validation)",
+			spec: Spec{
+				ValidationFailureAction: kyvernov1.Enforce,
+				ValidationFailureActionOverrides: []kyvernov1.ValidationFailureActionOverride{
+					{
+						Action: kyvernov1.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyvernov1.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []Rule{
+					{
+						Name: "require-labels",
+						MatchResources: MatchResources{
+							Any: kyvernov1.ResourceFilters{{
+								ResourceDescription: kyvernov1.ResourceDescription{
+									Kinds: []string{
+										"Pod",
+									},
+								},
+							}},
+						},
+						Validation: Validation{
+							Message: "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{
+								Raw: []byte(`
+							"metadata": {
+								"lables": {
+									"app.kubernetes.io/name": "?*"
+								}
+							}`),
+							},
+						},
+					},
+				},
+			},
+			expectedSpecErrIdx: 1,
+			errors: func(v *kyvernov1.ValidationFailureActionOverride) (errs field.ErrorList) {
+				return append(errs, field.Invalid(field.NewPath("dummy.validationFailureActionOverrides[1].namespaces"), v, "Duplicate namespaces found: default"))
+			},
+		},
+		{
+			description: "Duplicate Namespace in 2nd resource(mutate)",
+			spec: Spec{
+				ValidationFailureAction: kyvernov1.Enforce,
+				ValidationFailureActionOverrides: []kyvernov1.ValidationFailureActionOverride{
+					{
+						Action: kyvernov1.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyvernov1.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []Rule{
+					{
+						Name: "add-labels",
+						MatchResources: MatchResources{
+							Any: kyvernov1.ResourceFilters{{
+								ResourceDescription: kyvernov1.ResourceDescription{
+									Kinds: []string{
+										"Pod",
+									},
+								},
+							}},
+						},
+						Mutation: kyvernov1.Mutation{
+							RawPatchStrategicMerge: &apiextv1.JSON{
+								Raw: []byte(`
+								"metadata": {
+									"labels": {
+										"app-name": "{{request.object.metadata.name}}"
+									}
+								}`),
+							},
+						},
+					},
+				},
+			},
+			expectedSpecErrIdx: 1,
+			errors: func(v *kyvernov1.ValidationFailureActionOverride) (errs field.ErrorList) {
+				return append(errs, field.Invalid(field.NewPath("dummy.validationFailureActionOverrides[1].namespaces"), v, "Duplicate namespaces found: default"))
+			},
+		},
+	}
+
+	for _, ts := range testcases {
+		t.Run(ts.description, func(t *testing.T) {
+			errs := ts.spec.Validate(path, false, nil)
+
+			var expectedErrs field.ErrorList
+			if ts.errors != nil {
+				expectedErrs = ts.errors(&ts.spec.ValidationFailureActionOverrides[ts.expectedSpecErrIdx])
+			}
+
+			assert.Equal(t, len(errs), len(expectedErrs))
+			for i := range errs {
+				assert.Equal(t, errs[i].Error(), expectedErrs[i].Error())
+			}
+		})
+	}
+}

--- a/api/kyverno/v2beta1/spec_types.go
+++ b/api/kyverno/v2beta1/spec_types.go
@@ -2,6 +2,7 @@ package v2beta1
 
 import (
 	"fmt"
+	"strings"
 
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -224,11 +225,40 @@ func (s *Spec) ValidateRules(path *field.Path, namespaced bool, clusterResources
 	return errs
 }
 
+// ValidateNamespaces implements programmatic validation of Namespaces
+// defined under `ValidationFailureActionOverrides`
+func (s *Spec) ValidateNamespaces(path *field.Path) (errs field.ErrorList) {
+	action := map[kyvernov1.ValidationFailureAction]sets.String{
+		kyvernov1.Enforce: sets.NewString(),
+		kyvernov1.Audit:   sets.NewString(),
+	}
+
+	for i, vfa := range s.ValidationFailureActionOverrides {
+		if vfa.Action == kyvernov1.Audit {
+			if action[kyvernov1.Enforce].HasAny(vfa.Namespaces...) {
+				errs = append(errs, field.Invalid(path.Index(i).Child("namespaces"), vfa,
+					fmt.Sprintf("Duplicate namespaces found: %s", strings.Join(action[kyvernov1.Enforce].Intersection(sets.NewString(vfa.Namespaces...)).List(), ", "))))
+			}
+		} else if vfa.Action == kyvernov1.Enforce {
+			if action[kyvernov1.Audit].HasAny(vfa.Namespaces...) {
+				errs = append(errs, field.Invalid(path.Index(i).Child("namespaces"), vfa,
+					fmt.Sprintf("Duplicate namespaces found: %s", strings.Join(action[kyvernov1.Audit].Intersection(sets.NewString(vfa.Namespaces...)).List(), ", "))))
+			}
+		}
+		action[vfa.Action].Insert(vfa.Namespaces...)
+	}
+
+	return errs
+}
+
 // Validate implements programmatic validation
 func (s *Spec) Validate(path *field.Path, namespaced bool, clusterResources sets.String) (errs field.ErrorList) {
 	errs = append(errs, s.ValidateRules(path.Child("rules"), namespaced, clusterResources)...)
 	if namespaced && len(s.ValidationFailureActionOverrides) > 0 {
 		errs = append(errs, field.Forbidden(path.Child("validationFailureActionOverrides"), "Use of validationFailureActionOverrides is supported only with ClusterPolicy"))
+	}
+	if !namespaced {
+		errs = append(errs, s.ValidateNamespaces(path.Child("validationFailureActionOverrides"))...)
 	}
 	return errs
 }

--- a/pkg/policycache/cache_test.go
+++ b/pkg/policycache/cache_test.go
@@ -1159,3 +1159,100 @@ func Test_Validate_Enforce_Policy(t *testing.T) {
 		t.Errorf("removing: expected 0 validate audit policy, found %v", len(validateAudit))
 	}
 }
+
+func Test_Get_Policies(t *testing.T) {
+	cache := NewCache()
+	policy := newPolicy(t)
+	key, _ := kubecache.MetaNamespaceKeyFunc(policy)
+	cache.Set(key, policy)
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Namespace", "")
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Namespace", "")
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	mutate := cache.GetPolicies(Mutate, "Pod", "")
+	if len(mutate) != 1 {
+		t.Errorf("expected 1 mutate policy, found %v", len(mutate))
+	}
+
+	generate := cache.GetPolicies(Generate, "Pod", "")
+	if len(generate) != 1 {
+		t.Errorf("expected 1 generate policy, found %v", len(generate))
+	}
+
+}
+
+func Test_Get_Policies_Ns(t *testing.T) {
+	cache := NewCache()
+	policy := newNsPolicy(t)
+	key, _ := kubecache.MetaNamespaceKeyFunc(policy)
+	cache.Set(key, policy)
+	nspace := policy.GetNamespace()
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Pod", nspace)
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Pod", nspace)
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	mutate := cache.GetPolicies(Mutate, "Pod", nspace)
+	if len(mutate) != 1 {
+		t.Errorf("expected 1 mutate policy, found %v", len(mutate))
+	}
+
+	generate := cache.GetPolicies(Generate, "Pod", nspace)
+	if len(generate) != 1 {
+		t.Errorf("expected 1 generate policy, found %v", len(generate))
+	}
+}
+
+func Test_Get_Policies_Validate_Failure_Action_Overrides(t *testing.T) {
+	cache := NewCache()
+	policy1 := newValidateAuditPolicy(t)
+	policy2 := newValidateEnforcePolicy(t)
+	key1, _ := kubecache.MetaNamespaceKeyFunc(policy1)
+	cache.Set(key1, policy1)
+	key2, _ := kubecache.MetaNamespaceKeyFunc(policy2)
+	cache.Set(key2, policy2)
+
+	validateAudit := cache.GetPolicies(ValidateAudit, "Pod", "")
+	if len(validateAudit) != 1 {
+		t.Errorf("expected 1 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce := cache.GetPolicies(ValidateEnforce, "Pod", "")
+	if len(validateEnforce) != 1 {
+		t.Errorf("expected 1 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	validateAudit = cache.GetPolicies(ValidateAudit, "Pod", "test")
+	if len(validateAudit) != 2 {
+		t.Errorf("expected 2 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce = cache.GetPolicies(ValidateEnforce, "Pod", "test")
+	if len(validateEnforce) != 0 {
+		t.Errorf("expected 0 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+	validateAudit = cache.GetPolicies(ValidateAudit, "Pod", "default")
+	if len(validateAudit) != 0 {
+		t.Errorf("expected 0 validate audit policy, found %v", len(validateAudit))
+	}
+
+	validateEnforce = cache.GetPolicies(ValidateEnforce, "Pod", "default")
+	if len(validateEnforce) != 2 {
+		t.Errorf("expected 2 validate enforce policy, found %v", len(validateEnforce))
+	}
+
+}


### PR DESCRIPTION
## Explanation
PART 1:
currently when validation policy is created with  ValidationFailureActionOverride  and has ```enforce``` action defined for atleast one namespace, then validation always happens in validation webhook handler and even when it has action ```audit``` for a namespace in audit handler. this PR will add filter policies for audit/enforce considering resource namespace and ValidationFailureActionOverride.

PART 2:
From this PR discussion, it is identified that if the same namespace is provided with different actions we have to invalidate the policy creation by the end user. So policy validation to `validationFailureActionOverrides` field is implemented in this PR.

## Related issue

closes: 3058

## Milestone of this PR


## What type of PR is this
/kind bug
<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes
PART 1:
implemented policies filtering function if validationFailureActionOverride is defined.

PART 2:
For Policy validation, implemented a new function `ValidateNamespaces` to validate the namespace for Spec field.

### Proof Manifests

Test policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels-1
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - default
    - action: enforce
      namespaces:
        - test
        - default
  rules:
  - name: check-for-labels-1
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```

When applying the policy, we will throw the Invalid error to the user.
```shell
$ kc apply -f samp-cluster-plo.yml                                                                                                                                            
Error from server: error when creating "samp-cluster-plo.yml": admission webhook "validate-policy.kyverno.svc" denied the request: spec.validationFailureActionOverrides[1].namespaces: Invalid value: v1.ValidationFailureActionOverride{Action:"audit", Namespaces:[]string{"default"}}: Duplicate namespaces found: default
$ kc get cpol                                                                                                                                                                 
No resources found
```
Unit test cases also added to the test the functionality.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
