### PR TITLE
policy validation for ValidationFailureActionOverride field

### DIFF
--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -2,15 +2,17 @@ package policy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
 	"github.com/kyverno/kyverno/pkg/logging"
 	"github.com/kyverno/kyverno/pkg/openapi"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-
 	"gotest.tools/assert"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func Test_Validate_ResourceDescription_Empty(t *testing.T) {
@@ -1032,6 +1034,7 @@ func Test_Validate_ApiCall(t *testing.T) {
 		}
 	}
 }
+
 func Test_Wildcards_Kind(t *testing.T) {
 	rawPolicy := []byte(`
 	{
@@ -1441,4 +1444,435 @@ func Test_PodControllerAutoGenExclusion_None_Policy(t *testing.T) {
 		assert.Assert(t, res.Warnings != nil)
 	}
 	assert.NilError(t, err)
+}
+
+func Test_ValidateNamespace(t *testing.T) {
+	testcases := []struct {
+		description   string
+		spec          *kyverno.Spec
+		expectedError error
+	}{
+		{
+			description: "tc1",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("conflicting namespaces found in path: spec.validationFailureActionOverrides[1].namespaces: default"),
+		},
+		{
+			description: "tc2",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Mutation: kyverno.Mutation{
+							RawPatchStrategicMerge: &apiextv1.JSON{Raw: []byte(`"metadata": {"labels": {"app-name": "{{request.object.metadata.name}}"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("conflicting namespaces found in path: spec.validationFailureActionOverrides[1].namespaces: default"),
+		},
+		{
+			description: "tc3",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default*",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern 'default*' matches with namespace 'default'"),
+		},
+		{
+			description: "tc4",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '*' matches with namespace 'default'"),
+		},
+		{
+			description: "tc5",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"?*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '?*' matches with namespace 'default'"),
+		},
+		{
+			description: "tc6",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default?",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default1",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern 'default?' matches with namespace 'default1'"),
+		},
+		{
+			description: "tc7",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default*",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"?*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '?*' matches with namespace 'test'"),
+		},
+		{
+			description: "tc8",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"*",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"?*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '?*' conflicts with the pattern '*'"),
+		},
+		{
+			description: "tc9",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default*",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+							"test*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern 'test*' matches with namespace 'test'"),
+		},
+		{
+			description: "tc10",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"*efault",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '*efault' matches with namespace 'default'"),
+		},
+		{
+			description: "tc11",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default-*",
+							"test",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "tc12",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default*?",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+							"test*",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "tc13",
+			spec: &kyverno.Spec{
+				ValidationFailureAction: kyverno.Enforce,
+				ValidationFailureActionOverrides: []kyverno.ValidationFailureActionOverride{
+					{
+						Action: kyverno.Enforce,
+						Namespaces: []string{
+							"default?",
+						},
+					},
+					{
+						Action: kyverno.Audit,
+						Namespaces: []string{
+							"default",
+						},
+					},
+				},
+				Rules: []kyverno.Rule{
+					{
+						Name:           "require-labels",
+						MatchResources: kyverno.MatchResources{ResourceDescription: kyverno.ResourceDescription{Kinds: []string{"Pod"}}},
+						Validation: kyverno.Validation{
+							Message:    "label 'app.kubernetes.io/name' is required",
+							RawPattern: &apiextv1.JSON{Raw: []byte(`"metadata": {"lables": {"app.kubernetes.io/name": "?*"}}`)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validateNamespaces(tc.spec, field.NewPath("spec").Child("validationFailureActionOverrides"))
+			if tc.expectedError != nil {
+				assert.Error(t, err, tc.expectedError.Error())
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -358,3 +358,38 @@ func OverrideRuntimeErrorHandler() {
 		}
 	}
 }
+
+func SeperateWildcards(l []string) (lw []string, rl []string) {
+	for _, val := range l {
+		if wildcard.ContainsWildcard(val) {
+			lw = append(lw, val)
+		} else {
+			rl = append(rl, val)
+		}
+	}
+	return lw, rl
+}
+
+func CheckWildcardNamespaces(patterns []string, ns []string) (string, string, bool) {
+	for _, n := range ns {
+		pat, element, boolval := containsNamespaceWithStringReturn(patterns, n)
+		if boolval {
+			return pat, element, true
+		}
+	}
+	return "", "", false
+}
+
+func containsWithStringReturn(list []string, element string, fn func(string, string) bool) (string, string, bool) {
+	for _, e := range list {
+		if fn(e, element) {
+			return e, element, true
+		}
+	}
+	return "", "", false
+}
+
+// containsNamespaceWithStringReturn check if namespace satisfies any list of pattern(regex)
+func containsNamespaceWithStringReturn(patterns []string, ns string) (string, string, bool) {
+	return containsWithStringReturn(patterns, ns, comparePatterns)
+}

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -202,5 +202,182 @@ func Test_ConvertResource(t *testing.T) {
 		assert.Assert(t, resource.GetNamespace() == test.expectedNamespace)
 		break
 	}
+}
 
+func Test_SeperateWildcards(t *testing.T) {
+	testcases := []struct {
+		description string
+		inputList   []string
+		expList1    []string
+		expList2    []string
+	}{
+		{
+			description: "tc1",
+			inputList:   []string{"test*", "default", "default1", "hello"},
+			expList1:    []string{"test*"},
+			expList2:    []string{"default", "default1", "hello"},
+		},
+		{
+			description: "tc2",
+			inputList:   []string{"test*", "default*", "default1?", "hello?"},
+			expList1:    []string{"test*", "default*", "default1?", "hello?"},
+			expList2:    nil,
+		},
+		{
+			description: "tc3",
+			inputList:   []string{"test", "default", "default1", "hello"},
+			expList1:    nil,
+			expList2:    []string{"test", "default", "default1", "hello"},
+		},
+		{
+			description: "tc4",
+			inputList:   nil,
+			expList1:    nil,
+			expList2:    nil,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			list1, list2 := SeperateWildcards(tc.inputList)
+			assert.DeepEqual(t, list1, tc.expList1)
+			assert.DeepEqual(t, list2, tc.expList2)
+		})
+	}
+}
+
+func Test_CheckWildcardNamespaces(t *testing.T) {
+	testcases := []struct {
+		description   string
+		inputPatterns []string
+		inputNs       []string
+		expString1    string
+		expString2    string
+		expBool       bool
+	}{
+		{
+			description:   "tc1",
+			inputPatterns: []string{"default*", "test*"},
+			inputNs:       []string{"default", "default1"},
+			expString1:    "default*",
+			expString2:    "default",
+			expBool:       true,
+		},
+		{
+			description:   "tc2",
+			inputPatterns: []string{"test*"},
+			inputNs:       []string{"default1", "test"},
+			expString1:    "test*",
+			expString2:    "test",
+			expBool:       true,
+		},
+		{
+			description:   "tc3",
+			inputPatterns: []string{"*"},
+			inputNs:       []string{"default1", "test"},
+			expString1:    "*",
+			expString2:    "default1",
+			expBool:       true,
+		},
+		{
+			description:   "tc4",
+			inputPatterns: []string{"a*"},
+			inputNs:       []string{"default1", "test"},
+			expString1:    "",
+			expString2:    "",
+			expBool:       false,
+		},
+		{
+			description:   "tc5",
+			inputPatterns: nil,
+			inputNs:       []string{"default1", "test"},
+			expString1:    "",
+			expString2:    "",
+			expBool:       false,
+		},
+		{
+			description:   "tc6",
+			inputPatterns: []string{"*"},
+			inputNs:       nil,
+			expString1:    "",
+			expString2:    "",
+			expBool:       false,
+		},
+		{
+			description:   "tc7",
+			inputPatterns: nil,
+			inputNs:       nil,
+			expString1:    "",
+			expString2:    "",
+			expBool:       false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			str1, str2, actualBool := CheckWildcardNamespaces(tc.inputPatterns, tc.inputNs)
+			assert.Equal(t, str1, tc.expString1)
+			assert.Equal(t, str2, tc.expString2)
+			assert.Equal(t, actualBool, tc.expBool)
+		})
+	}
+}
+
+func Test_containsNamespaceWithStringReturn(t *testing.T) {
+	testcases := []struct {
+		description  string
+		inputPattern []string
+		inputNs      string
+		expStr1      string
+		expStr2      string
+		expBool      bool
+	}{
+		{
+			description:  "tc1",
+			inputPattern: []string{"default*"},
+			inputNs:      "default",
+			expStr1:      "default*",
+			expStr2:      "default",
+			expBool:      true,
+		},
+		{
+			description:  "tc2",
+			inputPattern: []string{"*"},
+			inputNs:      "default",
+			expStr1:      "*",
+			expStr2:      "default",
+			expBool:      true,
+		},
+		{
+			description:  "tc3",
+			inputPattern: []string{"*"},
+			inputNs:      "default",
+			expStr1:      "*",
+			expStr2:      "default",
+			expBool:      true,
+		},
+		{
+			description:  "tc4",
+			inputPattern: nil,
+			inputNs:      "default",
+			expStr1:      "",
+			expStr2:      "",
+			expBool:      false,
+		},
+		{
+			description:  "tc5",
+			inputPattern: nil,
+			inputNs:      "",
+			expStr1:      "",
+			expStr2:      "",
+			expBool:      false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			str1, str2, actualBool := containsNamespaceWithStringReturn(tc.inputPattern, tc.inputNs)
+			assert.Equal(t, str1, tc.expStr1)
+			assert.Equal(t, str2, tc.expStr2)
+			assert.Equal(t, actualBool, tc.expBool)
+		})
+	}
 }


### PR DESCRIPTION
## Explanation

Currently `validationFailureActionOverrides` field is not provided with validation of the namespaces for different actions defined in it. A policy can be created without validation even if the same namespace defined under different actions.

In this manifest we can observe that `default` namespace is mistakenly configured for both the actions. In the current release, this policy will be created.
 
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - prod
        - default
    - action: enforce
      namespaces:
        - test
        - default
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```

```shell
$ kc apply -f sample-cluster-policy.yml                                                                                                                                             
clusterpolicy.kyverno.io/require-labels created
```

This PR aims to address the validation  of namespaces in  `validationFailureActionOverrides` field.

## Related issue

Closes : 3058 (partial)

## Milestone of this PR

## What type of PR is this
/kind bug

## Proposed Changes

Validation of namespaces for field `validationFailureActionOverrides` is implemented and also handled wildcard patterns for namespaces.

### Proof Manifests

#### Namespace with no wildcard pattern
Below manifest will not be created as the namespace is mistakenly defined again with other action.

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - prod
        - default
    - action: enforce
      namespaces:
        - test
        - default
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```
Detailed error will be thrown and policy not created.
```shell
$ kc apply -f sample-cluster-policy.yml
Error from server: error when creating "sample-cluster-policy.yml": admission webhook "validate-policy.kyverno.svc" denied the request: conflicting namespaces found in path: spec.validationFailureActionOverrides[1].namespaces: default
$ kc get cpol
No resources found
```
Controller log
```log
E0922 18:57:34.600816 1355420 handlers.go:43] webhooks/policy/validate "msg"="policy validation errors" "error"="conflicting namespaces found in path: spec.validationFailureActionOverrides[1].namespaces: default" "kind"={"group":"kyverno.io","version":"v1","kind":"ClusterPolicy"} "name"="require-labels" "namespace"="" "operation"="CREATE" "uid"="bdb8b0e6-b0cd-47a9-a3f0-dfbb3b83e7dc" 
```

#### Namespaces with wildcard pattern - 1(Other variations)
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - prod
        - default*
    - action: enforce
      namespaces:
        - default
        - test
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```
Shell output
```shell
$ kc apply -f sample-cluster-policy.yml
Error from server: error when creating "sample-cluster-policy.yml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern 'default*' matches with namespace 'default'
$ kc get cpol
No resources found
```

#### Namespaces with wildcard pattern - 2

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - "*"
    - action: enforce
      namespaces:
        - prod
        - stage
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```
Shell output
```shell
$ kc apply -f sample-cluster-policy.yml
Error from server: error when creating "sample-cluster-policy.yml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern '*' matches with namespace 'prod'
$ kc get cpol
No resources found
```

#### Namespaces with wildcard pattern - 3

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: require-labels
spec:
  validationFailureAction: enforce
  validationFailureActionOverrides:
    - action: audit
      namespaces:
        - p*
    - action: enforce
      namespaces:
        - prod*
  rules:
  - name: check-for-labels
    match:
      any:
      - resources:
          kinds:
          - Pod
    validate:
      message: "label 'app.kubernetes.io/name' is required"
      pattern:
        metadata:
          labels:
            app.kubernetes.io/name: "?*"
```
Shell output
```shell
$ kc apply -f sample-cluster-policy.yml                                                                                             1 ↵
Error from server: error when creating "sample-cluster-policy.yml": admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.validationFailureActionOverrides[1].namespaces: wildcard pattern 'p*' conflicts with the pattern 'prod*'
$ kc get cpol
No resources found
```
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
