### PR TITLE
Added support to specify key signature algorithm in verifyImages

### DIFF
--- a/api/kyverno/v1/image_verification_types.go
+++ b/api/kyverno/v1/image_verification_types.go
@@ -132,6 +132,10 @@ type StaticKeyAttestor struct {
 	// attestors and the count is applied across the keys.
 	PublicKeys string `json:"publicKeys,omitempty" yaml:"publicKeys,omitempty"`
 
+	// Specify signature algorithm for public keys. Supported values are sha256 and sha512
+	// +kubebuilder:default=sha256
+	SignatureAlgorithm string `json:"signatureAlgorithm,omitempty" yaml:"signatureAlgorithm,omitempty"`
+
 	// Rekor provides configuration for the Rekor transparency log service. If the value is nil,
 	// Rekor is not checked. If an empty object is provided the public instance of
 	// Rekor (https://rekor.sigstore.dev) is used.
@@ -305,7 +309,9 @@ func (ska *StaticKeyAttestor) Validate(path *field.Path) (errs field.ErrorList) 
 	if ska.PublicKeys == "" {
 		errs = append(errs, field.Invalid(path, ska, "A key is required"))
 	}
-
+	if ska.PublicKeys != "" && ska.SignatureAlgorithm != "sha256" && ska.SignatureAlgorithm != "sha512" {
+		errs = append(errs, field.Invalid(path, ska, "Invalid signature algorithm provided"))
+	}
 	return errs
 }
 

--- a/charts/kyverno/templates/crds.yaml
+++ b/charts/kyverno/templates/crds.yaml
@@ -2399,6 +2399,10 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -2686,6 +2690,10 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -4136,6 +4144,10 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -4423,6 +4435,10 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -5824,6 +5840,10 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -6101,6 +6121,10 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -7536,6 +7560,10 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -7823,6 +7851,10 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -9820,6 +9852,10 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -10107,6 +10143,10 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -11557,6 +11597,10 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -11844,6 +11888,10 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -13245,6 +13293,10 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -13522,6 +13574,10 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -14957,6 +15013,10 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.
@@ -15244,6 +15304,10 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm for public keys. Supported values are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule. If specified Repository will override other OCI image repository locations for this Attestor.

--- a/config/crds/kyverno.io_clusterpolicies.yaml
+++ b/config/crds/kyverno.io_clusterpolicies.yaml
@@ -2291,6 +2291,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -2726,6 +2732,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -5148,6 +5160,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -5595,6 +5613,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -7804,6 +7828,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -8224,6 +8254,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -10621,6 +10657,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -11068,6 +11110,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional

--- a/config/crds/kyverno.io_policies.yaml
+++ b/config/crds/kyverno.io_policies.yaml
@@ -2292,6 +2292,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -2727,6 +2733,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -5150,6 +5162,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -5597,6 +5615,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -7807,6 +7831,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -8227,6 +8257,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -10624,6 +10660,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -11071,6 +11113,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -3585,6 +3585,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -4020,6 +4026,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -6442,6 +6454,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -6889,6 +6907,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -9098,6 +9122,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -9518,6 +9548,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -11915,6 +11951,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -12362,6 +12404,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -15384,6 +15432,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -15819,6 +15873,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -18242,6 +18302,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -18689,6 +18755,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -20899,6 +20971,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -21319,6 +21397,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -23716,6 +23800,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -24163,6 +24253,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional

--- a/config/install_debug.yaml
+++ b/config/install_debug.yaml
@@ -3579,6 +3579,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -4014,6 +4020,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -6436,6 +6448,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -6883,6 +6901,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -9092,6 +9116,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -9512,6 +9542,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -11909,6 +11945,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -12356,6 +12398,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -15375,6 +15423,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -15810,6 +15864,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -18233,6 +18293,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -18680,6 +18746,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional
@@ -20890,6 +20962,12 @@ spec:
                                               required:
                                               - url
                                               type: object
+                                            signatureAlgorithm:
+                                              default: sha256
+                                              description: Specify signature algorithm
+                                                for public keys. Supported values
+                                                are sha256 and sha512
+                                              type: string
                                           type: object
                                         repository:
                                           description: Repository is an optional alternate
@@ -21310,6 +21388,12 @@ spec:
                                             required:
                                             - url
                                             type: object
+                                          signatureAlgorithm:
+                                            default: sha256
+                                            description: Specify signature algorithm
+                                              for public keys. Supported values are
+                                              sha256 and sha512
+                                            type: string
                                         type: object
                                       repository:
                                         description: Repository is an optional alternate
@@ -23707,6 +23791,12 @@ spec:
                                                   required:
                                                   - url
                                                   type: object
+                                                signatureAlgorithm:
+                                                  default: sha256
+                                                  description: Specify signature algorithm
+                                                    for public keys. Supported values
+                                                    are sha256 and sha512
+                                                  type: string
                                               type: object
                                             repository:
                                               description: Repository is an optional
@@ -24154,6 +24244,12 @@ spec:
                                                 required:
                                                 - url
                                                 type: object
+                                              signatureAlgorithm:
+                                                default: sha256
+                                                description: Specify signature algorithm
+                                                  for public keys. Supported values
+                                                  are sha256 and sha512
+                                                type: string
                                             type: object
                                           repository:
                                             description: Repository is an optional

--- a/docs/crd/v1/index.html
+++ b/docs/crd/v1/index.html
@@ -3405,6 +3405,17 @@ attestors and the count is applied across the keys.</p>
 </tr>
 <tr>
 <td>
+<code>signatureAlgorithm</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specify signature algorithm for public keys. Supported values are sha256 and sha512</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>rekor</code><br/>
 <em>
 <a href="#kyverno.io/v1.CTLog">

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -46,6 +46,7 @@ type Options struct {
 	Annotations          map[string]string
 	Repository           string
 	RekorURL             string
+	SignatureAlgorithm   string
 }
 
 type Response struct {
@@ -115,6 +116,10 @@ func verifySignature(opts Options) (*Response, error) {
 func buildCosignOptions(opts Options) (*cosign.CheckOpts, error) {
 	var remoteOpts []remote.Option
 	var err error
+	var signatureAlgorithmMap = map[string]crypto.Hash{
+		"sha256": crypto.SHA256,
+		"sha512": crypto.SHA512,
+	}
 	ro := options.RegistryOptions{}
 	remoteOpts, err = ro.ClientOpts(context.Background())
 	if err != nil {
@@ -142,7 +147,8 @@ func buildCosignOptions(opts Options) (*cosign.CheckOpts, error) {
 
 	if opts.Key != "" {
 		if strings.HasPrefix(strings.TrimSpace(opts.Key), "-----BEGIN PUBLIC KEY-----") {
-			cosignOpts.SigVerifier, err = decodePEM([]byte(opts.Key))
+
+			cosignOpts.SigVerifier, err = decodePEM([]byte(opts.Key), signatureAlgorithmMap[opts.SignatureAlgorithm])
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to load public key from PEM")
 			}
@@ -406,14 +412,14 @@ func stringToJSONMap(i interface{}) (map[string]interface{}, error) {
 	return data, nil
 }
 
-func decodePEM(raw []byte) (signature.Verifier, error) {
+func decodePEM(raw []byte, signatureAlgorithm crypto.Hash) (signature.Verifier, error) {
 	// PEM encoded file.
 	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
 		return nil, errors.Wrap(err, "pem to public key")
 	}
 
-	return signature.LoadVerifier(pubKey, crypto.SHA256)
+	return signature.LoadVerifier(pubKey, signatureAlgorithm)
 }
 
 func extractPayload(verified []oci.Signature) ([]payload.SimpleContainerImage, error) {

--- a/pkg/engine/imageVerify.go
+++ b/pkg/engine/imageVerify.go
@@ -429,6 +429,7 @@ func (iv *imageVerifier) buildOptionsAndPath(attestor kyvernov1.Attestor, imageV
 		if attestor.Keys.Rekor != nil {
 			opts.RekorURL = attestor.Keys.Rekor.URL
 		}
+		opts.SignatureAlgorithm = attestor.Keys.SignatureAlgorithm
 	} else if attestor.Certificates != nil {
 		path = path + ".certificates"
 		opts.Cert = attestor.Certificates.Certificate

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -253,6 +253,16 @@ func Validate(policy kyvernov1.PolicyInterface, client dclient.Interface, mock b
 			}
 		}
 
+		if rule.HasVerifyImages() {
+			verifyImagePath := rulePath.Child("verifyImages")
+			for index, i := range rule.VerifyImages {
+				errs = append(errs, i.Validate(verifyImagePath.Index(index))...)
+			}
+			if len(errs) != 0 {
+				return nil, errs.ToAggregate()
+			}
+		}
+
 		podOnlyMap := make(map[string]bool) // Validate that Kind is only Pod
 		podOnlyMap["Pod"] = true
 		if reflect.DeepEqual(common.GetKindsFromRule(rule), podOnlyMap) && podControllerAutoGenExclusion(policy) {

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1226,6 +1226,159 @@ func Test_deny_exec(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func Test_SignatureAlgorithm(t *testing.T) {
+	testcases := []struct {
+		description    string
+		policy         []byte
+		expectedOutput bool
+	}{
+		{
+			description: "Test empty signature algorithm - pass",
+			policy: []byte(`{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "check-empty-signature-algorithm"
+				},
+				"spec": {
+					"rules": [
+						{
+							"match": {
+								"resources": {
+									"kinds": [
+										"Pod"
+									]
+								}
+							},
+							"verifyImages": [
+								{
+									"imageReferences": [
+										"ghcr.io/kyverno/test-verify-image:*"
+									],
+									"attestors": [
+										{
+											"count": 1,
+											"entries": [
+												{
+													"keys": {
+														"publicKeys": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM\n5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==\n-----END PUBLIC KEY-----"
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}`),
+			expectedOutput: true,
+		},
+		{
+			description: "Test invalid signature algorithm - fail",
+			policy: []byte(`{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "check-invalid-signature-algorithm"
+				},
+				"spec": {
+					"rules": [
+						{
+							"match": {
+								"resources": {
+									"kinds": [
+										"Pod"
+									]
+								}
+							},
+							"verifyImages": [
+								{
+									"imageReferences": [
+										"ghcr.io/kyverno/test-verify-image:*"
+									],
+									"attestors": [
+										{
+											"count": 1,
+											"entries": [
+												{
+													"keys": {
+														"publicKeys": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM\n5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==\n-----END PUBLIC KEY-----",
+														"signatureAlgorithm": "sha123"
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}`),
+			expectedOutput: false,
+		},
+		{
+			description: "Test invalid signature algorithm - fail",
+			policy: []byte(`{
+				"apiVersion": "kyverno.io/v1",
+				"kind": "ClusterPolicy",
+				"metadata": {
+					"name": "check-valid-signature-algorithm"
+				},
+				"spec": {
+					"rules": [
+						{
+							"match": {
+								"resources": {
+									"kinds": [
+										"Pod"
+									]
+								}
+							},
+							"verifyImages": [
+								{
+									"imageReferences": [
+										"ghcr.io/kyverno/test-verify-image:*"
+									],
+									"attestors": [
+										{
+											"count": 1,
+											"entries": [
+												{
+													"keys": {
+														"publicKeys": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM\n5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==\n-----END PUBLIC KEY-----",
+														"signatureAlgorithm": "sha256"
+													}
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}`),
+			expectedOutput: true,
+		},
+	}
+	for _, testcase := range testcases {
+		var policy *kyverno.ClusterPolicy
+		err := json.Unmarshal(testcase.policy, &policy)
+		assert.NilError(t, err)
+
+		openAPIController, _ := openapi.NewOpenAPIController()
+		_, err = Validate(policy, nil, true, openAPIController)
+		if testcase.expectedOutput {
+			assert.NilError(t, err)
+		} else {
+			assert.ErrorContains(t, err, "Invalid signature algorithm provided")
+		}
+	}
+}
+
 func Test_existing_resource_policy(t *testing.T) {
 	var err error
 	rawPolicy := []byte(`{


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Explanation

This PR adds support to specify signature algorithm in `verifyImages.attestors.entries.keys`. Currently Kyverno only supports sha256 crypto hash algorithm. This doesn't handle keys with sha512 hash algorithm. With this PR, user can specify algorithm type in Kyverno policy.

## Related issue
Closes 4433

## What type of PR is this
/kind feature

## Proposed Changes
- Added new field `SignatureAlgorithm` in `verifyImages.attestors.entries.keys`
- Updated CRDs to accommodate this field
- Modified `decodePEM` function to pass user specified algorithm or a default value `sha256`

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: check-image
spec:
  validationFailureAction: audit
  background: false
  webhookTimeoutSeconds: 30
  failurePolicy: Fail
  rules:
    - name: check-image
      match:
        any:
        - resources:
            kinds:
              - Pod
      verifyImages:
      - imageReferences:
        - "ghcr.io/kyverno/test-verify-image:*"
        attestors:
        - count: 1
          entries:
          - keys:
              publicKeys: |-
                -----BEGIN PUBLIC KEY-----
                MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM
                5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==
                -----END PUBLIC KEY-----
      - imageReferences:
        - "quay.io/jetstack/cert-manager-acmesolver:*"
        - "quay.io/jetstack/cert-manager-cainjector:*"
        - "quay.io/jetstack/cert-manager-ctl:*"
        - "quay.io/jetstack/cert-manager-controller:*"
        - "quay.io/jetstack/cert-manager-webhook:*"
        attestors:
        - count: 1
          entries:
          - keys:
              publicKeys: |-
                -----BEGIN PUBLIC KEY-----
                MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAsZZKaaIRjOpzbiWYIDKO
                yry9XGBqAfve1iOGmt5VO1jpjNoEseT6zewozHfWTM7osxayy2WjN8G+QV39MlT3
                Vxo91/31g+Zcq8KcvxG+iB8GRaD9pNgLmghorv+eYDiPYMO/+fhsLImyG5WEoPct
                MeCBD7umZ/A2t96U9DQxVDqQbTHlsNludno1p1wsgRnfUM3QHexNljDvJg5FcDMo
                dCpVLpRNvbw0lbJVfybJ4siJ5o/MmXzy0QCJpw+yMIqvqMc8qgKJ1yooJtuTVF4t
                4/luP+EG/oVIiSWCFeRMqYdbJ3R+CJi+4LN7vFNYQM1Q/NwOB52RteaR7wnqmcBz
                qSYK32MM8xdPCQ5tioWwnPTRbPZuzsZsRmJsKBO9JUrBYdDntZX1xY5g4QNSufxi
                QgJgJSU7E4VGMvagEzB1JzvOr6A/qNFCO1Z6JsA3jw3cJLV1rSHfxqfSXBACTLDf
                6bOPWRILRKydTJA6uLKNKmo1/nFm3jvd5tHKOjy4VAQLJ/Vx9wBsAAiLa+06veun
                Oz3AJ9sNh3wLp21RL11u9TuOKRBipE/TYsBYp8jpIyWPXDSV+JcD/TZqoT8y0Z6S
                0damfUmspuK9DTQFL2crpeaqJSG9RA+OuPZLxGD1IMURTsPJB7kXhPtmceeirBnw
                sVcRHHDitVt8oO/x4Wus1c0CAwEAAQ==
                -----END PUBLIC KEY-----
              signatureAlgorithm: sha512
```
Create resource with empty signatureAlgorithm
```bash
$ kubectl run test1 --image ghcr.io/kyverno/test-verify-image:signed
pod/test1 created
```
Create resource with valid sha512 signatureAlgorithm
```bash
$ kubectl run test2 --image quay.io/jetstack/cert-manager-ctl:v1.9.1
pod/test2 created
```
With invalid signatureAlgorithm in policy, we get following error while creating policy. (changed signatureAlgorithm in policy from `sha512` to `sha123`
```bash
Error from server: error when creating "../issue-4433.yaml": admission webhook "validate-policy.kyverno.svc" denied the request: spec.rules[0].verifyImages[1].attestors[0].entries[0].keys: Invalid value: v1.StaticKeyAttestor{PublicKeys:"-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAsZZKaaIRjOpzbiWYIDKO\nyry9XGBqAfve1iOGmt5VO1jpjNoEseT6zewozHfWTM7osxayy2WjN8G+QV39MlT3\nVxo91/31g+Zcq8KcvxG+iB8GRaD9pNgLmghorv+eYDiPYMO/+fhsLImyG5WEoPct\nMeCBD7umZ/A2t96U9DQxVDqQbTHlsNludno1p1wsgRnfUM3QHexNljDvJg5FcDMo\ndCpVLpRNvbw0lbJVfybJ4siJ5o/MmXzy0QCJpw+yMIqvqMc8qgKJ1yooJtuTVF4t\n4/luP+EG/oVIiSWCFeRMqYdbJ3R+CJi+4LN7vFNYQM1Q/NwOB52RteaR7wnqmcBz\nqSYK32MM8xdPCQ5tioWwnPTRbPZuzsZsRmJsKBO9JUrBYdDntZX1xY5g4QNSufxi\nQgJgJSU7E4VGMvagEzB1JzvOr6A/qNFCO1Z6JsA3jw3cJLV1rSHfxqfSXBACTLDf\n6bOPWRILRKydTJA6uLKNKmo1/nFm3jvd5tHKOjy4VAQLJ/Vx9wBsAAiLa+06veun\nOz3AJ9sNh3wLp21RL11u9TuOKRBipE/TYsBYp8jpIyWPXDSV+JcD/TZqoT8y0Z6S\n0damfUmspuK9DTQFL2crpeaqJSG9RA+OuPZLxGD1IMURTsPJB7kXhPtmceeirBnw\nsVcRHHDitVt8oO/x4Wus1c0CAwEAAQ==\n-----END PUBLIC KEY-----", SignatureAlgorithm:"sha123", Rekor:(*v1.CTLog)(nil)}: Invalid signature algorithm provided
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->