### PR TITLE
Fixed issue-3709: Image verify rule gives error for non-existing configmap

### DIFF
--- a/pkg/engine/imageVerifyValidate.go
+++ b/pkg/engine/imageVerifyValidate.go
@@ -19,6 +19,13 @@ func processImageValidationRule(log logr.Logger, ctx *PolicyContext, rule *kyver
 	}
 
 	log = log.WithValues("rule", rule.Name)
+	runValidation, err := requiredValidation(ctx, rule)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to load image info: %s", err.Error()))
+	}
+	if !runValidation {
+		return ruleResponse(*rule, response.Validation, "image verified", response.RuleStatusPass, nil)
+	}
 	if err := LoadContext(log, rule.Context, ctx, rule.Name); err != nil {
 		if _, ok := err.(gojmespath.NotFoundError); ok {
 			log.V(3).Info("failed to load context", "reason", err.Error())

--- a/pkg/engine/imageVerify_test.go
+++ b/pkg/engine/imageVerify_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	kyverno "github.com/kyverno/kyverno/api/kyverno/v1"
+	client "github.com/kyverno/kyverno/pkg/clients/dclient"
 	"github.com/kyverno/kyverno/pkg/cosign"
 	"github.com/kyverno/kyverno/pkg/engine/context"
 	"github.com/kyverno/kyverno/pkg/engine/response"
@@ -305,6 +306,63 @@ var testSampleMultipleKeyPolicy = `
 }
 `
 
+var testConfigMapMissing = `{
+    "apiVersion": "kyverno.io/v1",
+    "kind": "ClusterPolicy",
+    "metadata": {
+        "annotations": {
+            "pod-policies.kyverno.io/autogen-controllers": "none"
+        },
+        "name": "image-verify-polset"
+    },
+    "spec": {
+        "background": false,
+        "failurePolicy": "Fail",
+        "rules": [
+            {
+                "context": [
+                    {
+                        "configMap": {
+                            "name": "myconfigmap",
+                            "namespace": "somens"
+                        },
+                        "name": "myconfigmap"
+                    }
+                ],
+                "match": {
+                    "resources": {
+                        "kinds": [
+                            "Pod"
+                        ]
+                    }
+                },
+                "name": "image-verify-pol1",
+				"verifyImages": [
+                    {
+                        "imageReferences": [
+                            "ghcr.io/*"
+                        ],
+                        "attestors": [
+                            {
+                                "count": 1,
+                                "entries": [
+                                    {
+                                        "keys": {
+                                            "publicKeys": "{{myconfigmap.data.configmapkey}}"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "validationFailureAction": "audit",
+        "webhookTimeoutSeconds": 30
+    }
+}`
+
 var testSampleResource = `{
   "apiVersion": "v1",
   "kind": "Pod",
@@ -319,8 +377,45 @@ var testSampleResource = `{
   }
 }`
 
+var testConfigMapMissingResource = `{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "run": "test"
+        },
+        "name": "test"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "nginx:latest",
+                "name": "test",
+                "resources": {}
+            }
+        ]
+    }
+}`
+
 var testVerifyImageKey = `-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8nXRh950IZbRj8Ra/N9sbqOPZrfM5/KAQN0/KjHcorm/J5yctVd7iEcnessRQjU917hmKO6JWVGHpDguIyakZA==\n-----END PUBLIC KEY-----\n`
 var testOtherKey = `-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpNlOGZ323zMlhs4bcKSpAKQvbcWi5ZLRmijm6SqXDy0Fp0z0Eal+BekFnLzs8rUXUaXlhZ3hNudlgFJH+nFNMw==\n-----END PUBLIC KEY-----\n`
+
+func Test_ConfigMapMissingSuccess(t *testing.T) {
+	policyContext := buildContext(t, testConfigMapMissing, testConfigMapMissingResource, "")
+	cosign.ClearMock()
+	err, _ := VerifyAndPatchImages(policyContext)
+	assert.Equal(t, len(err.PolicyResponse.Rules), 0)
+}
+
+func Test_ConfigMapMissingFailure(t *testing.T) {
+	ghcrImage := strings.Replace(testConfigMapMissingResource, "nginx:latest", "ghcr.io/kyverno/test-verify-image:signed", -1)
+	policyContext := buildContext(t, testConfigMapMissing, ghcrImage, "")
+	policyContext.Client = client.NewEmptyFakeClient()
+	cosign.ClearMock()
+	err, _ := VerifyAndPatchImages(policyContext)
+	assert.Equal(t, len(err.PolicyResponse.Rules), 1)
+	assert.Equal(t, err.PolicyResponse.Rules[0].Status, response.RuleStatusError, err.PolicyResponse.Rules[0].Message)
+}
 
 func Test_SignatureGoodSigned(t *testing.T) {
 	policyContext := buildContext(t, testSampleSingleKeyPolicy, testSampleResource, "")


### PR DESCRIPTION
Signed-off-by: Pratik Shah <pratik@infracloud.io>

## Explanation

This PR doesn't verify resource images which are different from policy images. This allows user to create resources even if there are image verification errors.
 
## Related issue
Closes 3709

## Milestone of this PR
/milestone 1.8.2

## What type of PR is this
/kind bug

## Proposed Changes
This PR adds `requiredValidation` function which checks resource image is same or is contained by policy rule image. If function returns `true`, we run image verification normally. If function returns `false`, we skip the image verification and silently pass from image verification method.

### Proof Manifests
Policy:
```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  annotations:
    pod-policies.kyverno.io/autogen-controllers: none
  name: image-verify-polset
spec:
  background: false
  failurePolicy: Fail
  rules:
  - context:
    - configMap:
        name: myconfigmap
        namespace: somens
      name: myconfigmap
    match:
      resources:
        kinds:
        - Pod
    name: image-verify-pol1
    verifyImages:
    - image: ghcr.io/*
      key: '{{myconfigmap.data.configmapkey}}'
  validationFailureAction: audit
  webhookTimeoutSeconds: 30
```
NOTE: we haven't created configmap mentioned in the policy
Resource:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: test
  name: test
spec:
  containers:
  - image: ghcr.io/kyverno/test-verify-image:signed
    name: test
    resources: {}
```
On resource creation (this should fail)
```bash
$ kubectl create -f ../resource.yaml 
Error from server: error when creating "../resource.yaml": admission webhook "mutate.kyverno.svc-fail" denied the request: 

policy Pod/default/test for resource error: 

image-verify-polset:
  image-verify-pol1: 'failed to load context: failed to retrieve config map for context
    entry myconfigmap: failed to get configmap somens/myconfigmap : configmaps "myconfigmap"
    not found'
```
Change image field in resource.yaml to `nginx:latest`
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: test
  name: test
spec:
  containers:
  - image: nginx:latest
    name: test
    resources: {}
```
Create resource (this should create test pod)
```bash
$ kubectl create -f ../resource.yaml 
pod/test created
```

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
