### PR TITLE
fix(reports-controller): Allow `UPDATE` Operation in Resource Validation for Reports Controller

### DIFF
--- a/pkg/controllers/report/utils/scanner.go
+++ b/pkg/controllers/report/utils/scanner.go
@@ -105,7 +105,9 @@ func (s *scanner) validateResource(ctx context.Context, resource unstructured.Un
 		WithNewResource(resource).
 		WithPolicy(policy).
 		WithNamespaceLabels(nsLabels)
-	response := s.engine.Validate(ctx, policyCtx)
+	response := s.engine.Validate(ctx, policyCtx,
+		[]kyvernov1.AdmissionOperation{kyvernov1.Create, kyvernov1.Update}..., // Pass operations that are allowed
+	)
 	return &response, nil
 }
 

--- a/pkg/engine/api/engine.go
+++ b/pkg/engine/api/engine.go
@@ -19,6 +19,7 @@ type Engine interface {
 	Validate(
 		ctx context.Context,
 		policyContext PolicyContext,
+		allowedOperations ...kyvernov1.AdmissionOperation,
 	) EngineResponse
 
 	// Mutate performs mutation. Overlay first and then mutation patches

--- a/pkg/engine/background.go
+++ b/pkg/engine/background.go
@@ -87,10 +87,10 @@ func (e *engine) filterRule(
 	policy := policyContext.Policy()
 	gvk, subresource := policyContext.ResourceKind()
 
-	if err := engineutils.MatchesResourceDescription(newResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation()); err != nil {
+	if err := engineutils.MatchesResourceDescription(newResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, []kyvernov1.AdmissionOperation{policyContext.Operation()}); err != nil {
 		if ruleType == engineapi.Generation {
 			// if the oldResource matched, return "false" to delete GR for it
-			if err = engineutils.MatchesResourceDescription(oldResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, policyContext.Operation()); err == nil {
+			if err = engineutils.MatchesResourceDescription(oldResource, rule, admissionInfo, namespaceLabels, policy.GetNamespace(), gvk, subresource, []kyvernov1.AdmissionOperation{policyContext.Operation()}); err == nil {
 				return engineapi.RuleFail(rule.Name, ruleType, "")
 			}
 		}

--- a/pkg/engine/validation.go
+++ b/pkg/engine/validation.go
@@ -17,6 +17,7 @@ func (e *engine) validate(
 	ctx context.Context,
 	logger logr.Logger,
 	policyContext engineapi.PolicyContext,
+	allowedOperations []kyvernov1.AdmissionOperation,
 ) engineapi.PolicyResponse {
 	resp := engineapi.NewPolicyResponse()
 	policy := policyContext.Policy()
@@ -69,6 +70,7 @@ func (e *engine) validate(
 			matchedResource,
 			rule,
 			engineapi.Validation,
+			allowedOperations...,
 		)
 		matchedResource = resource
 		resp.Add(engineapi.NewExecutionStats(startTime, time.Now()), ruleResp...)

--- a/pkg/webhooks/resource/generation/handler.go
+++ b/pkg/webhooks/resource/generation/handler.go
@@ -321,7 +321,7 @@ func (h *generationHandler) processRequest(ctx context.Context, policyContext *e
 					policy.GetNamespace(),
 					gvk,
 					subresource,
-					policyContext.Operation(),
+					[]kyvernov1.AdmissionOperation{policyContext.Operation()},
 				); err == nil {
 					h.log.V(4).Info("skip creating UR as the admission resource is both the source and the trigger")
 					continue

--- a/test/conformance/chainsaw/deferred/dependencies/manifests.yaml
+++ b/test/conformance/chainsaw/deferred/dependencies/manifests.yaml
@@ -19,6 +19,7 @@ spec:
           - Deployment
           operations:
           - CREATE
+          - UPDATE
     context:
     # Mocked response from the Kubecost prediction API until it natively supports JSON input. 
     # Get the predicted amount of the Deployment and transform to get the totalMonthlyRate.


### PR DESCRIPTION
## Explanation

Allow `UPDATE` operation in validation.
    
Pass operations list instead of one to check for resources that match the policy's condition block.
    
Also, decouple the operation list for resource validation from the policy context's operation.

## Related issue

9562

## Milestone of this PR

NA

## Documentation (optional)

NA

## What type of PR is this

/kind bug

## Proposed Changes

Allow `UPDATE` operation in validation.
    
Pass operations list instead of one to check for resources that match the policy's condition block.
    
Also, decouple the operation list for resource validation from the policy context's operation.

### Proof Manifests

Included in issue 9562

### Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

NA

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.

## Further Comments

NA
